### PR TITLE
Improve performance of trim 68x on large strings

### DIFF
--- a/src/main/java/com/github/vertical_blank/sqlformatter/core/util/Util.java
+++ b/src/main/java/com/github/vertical_blank/sqlformatter/core/util/Util.java
@@ -19,7 +19,12 @@ public class Util {
 	}
 
 	public static String trimEnd(String s) {
-		return s.replaceAll("[ |\\n|\\r]*$", "");
+		int endIndex = s.length();
+		char[] chars = s.toCharArray();
+		while(endIndex > 0 && (chars[endIndex  - 1] == ' ' || chars[endIndex  - 1] == '\n' || chars[endIndex  - 1] == '\r')) {
+			endIndex--;
+		}
+		return new String(chars, 0, endIndex);
 	}
 
 	public static String escapeRegExp(String s) {

--- a/src/test/groovy/com/github/vertical_blank/sqlformatter/core/util/UtilTest.groovy
+++ b/src/test/groovy/com/github/vertical_blank/sqlformatter/core/util/UtilTest.groovy
@@ -9,5 +9,17 @@ class UtilTest {
         def escaped = Util.escapeRegExp('[lodash](https://lodash.com/)')
         assert escaped == '''\\[lodash\\]\\(https://lodash\\.com/\\)'''
     }
+    @Test
+    void testTrimEnd() {
+        assert "" == Util.trimEnd(" ");
+        assert "" == Util.trimEnd("");
+        assert " \r\nabc" == Util.trimEnd(" \r\nabc");
+        assert " \r\nabc" == Util.trimEnd(" \r\nabc ");
+        assert " \r\nabc" == Util.trimEnd(" \r\nabc\n");
+        assert " \r\nabc" == Util.trimEnd(" \r\nabc\r");
+        assert " \r\nabc" == Util.trimEnd(" \r\nabc\r\n");
+        assert " \r\nabc" == Util.trimEnd(" \r\nabc\r\n ");
+        assert " \r\nabc" == Util.trimEnd(" \r\nabc   \r\n  \n  ");
+    }
 
 }


### PR DESCRIPTION
Large SQL statement, around 6000 lines.

Warmup 50K runs then each run 50K times:

Elapsed time trimEnd: 22064ms
Elapsed time trimEnd: 323ms