### PR TITLE
Remove NPE if comma exists before reserved word

### DIFF
--- a/src/main/java/com/github/vertical_blank/sqlformatter/core/Formatter.java
+++ b/src/main/java/com/github/vertical_blank/sqlformatter/core/Formatter.java
@@ -163,7 +163,7 @@ public class Formatter {
 
 		if (this.inlineBlock.isActive()) {
 			return query;
-		} else if (this.previousReservedWord.value.matches("(?i)^LIMIT$")) {
+		} else if (this.previousReservedWord != null && this.previousReservedWord.value.matches("(?i)^LIMIT$")) {
 			return query;
 		} else {
 			return this.addNewline(query);


### PR DESCRIPTION
Remove NPE if comma exists before reserved word for example when using Teradata's SEL for SELECT

Change-Id: I0724dc7ff8b8a908882578a9d0005d475d50062d