### PR TITLE
Add fatArrow `=>` in Tokenizer

### DIFF
--- a/src/main/java/com/github/vertical_blank/sqlformatter/core/Tokenizer.java
+++ b/src/main/java/com/github/vertical_blank/sqlformatter/core/Tokenizer.java
@@ -49,7 +49,7 @@ public class Tokenizer {
 	public Tokenizer(DialectConfig cfg) {
 		this.WHITESPACE_REGEX = "^(\\s+)";
 		this.NUMBER_REGEX = "^((-\\s*)?[0-9]+(\\.[0-9]+)?|0x[0-9a-fA-F]+|0b[01]+)\\b";
-		this.OPERATOR_REGEX = "^(!=|<>|==|<=|>=|!<|!>|\\|\\||::|->>|->|~~\\*|~~|!~~\\*|!~~|~\\*|!~\\*|!~|.)";
+		this.OPERATOR_REGEX = "^(!=|<>|==|<=|>=|!<|!>|\\|\\||::|->>|=>|->|~~\\*|~~|!~~\\*|!~~|~\\*|!~\\*|!~|.)";
 
 //        this.BLOCK_COMMENT_REGEX = /^(\/\*[^]*?(?:\*\/|$))/;
 		this.BLOCK_COMMENT_REGEX = "^(/\\*(?s).*?(?:\\*/|$))";

--- a/src/test/java/com/github/vertical_blank/sqlformatter/SqlFormatterTest.java
+++ b/src/test/java/com/github/vertical_blank/sqlformatter/SqlFormatterTest.java
@@ -59,6 +59,17 @@ public class SqlFormatterTest {
 	}
 
 	@Test
+	public void withFatArrow() {
+		String format = SqlFormatter.format("SELECT * FROM tbl WHERE foo => '123'");
+		assertEquals(format, "SELECT\n" +
+				"  *\n" +
+				"FROM\n" +
+				"  tbl\n" +
+				"WHERE\n" +
+				"  foo => '123'");
+	}
+
+	@Test
 	public void withIndexedParams() {
 		String format = SqlFormatter.format("SELECT * FROM tbl WHERE foo = ?", Arrays.asList("'bar'"));
 		assertEquals(format, "SELECT\n" +


### PR DESCRIPTION
Currently the formatter adds a space between `=` and `>` whenever it formats a fatArrow. This PR fixes it.