### PR TITLE
Reusing compiled regex patterns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,13 @@
       <version>2.5.6</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>1.19</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/github/vertical_blank/sqlformatter/core/util/Util.java
+++ b/src/main/java/com/github/vertical_blank/sqlformatter/core/util/Util.java
@@ -10,6 +10,11 @@ import java.util.stream.Stream;
 
 public class Util {
 
+	private static final String ESCAPE_REGEX = Stream.of("^", "$", "\\", ".", "*", "+", "*", "?", "(", ")", "[", "]", "{", "}", "|")
+			.map(spChr -> "(\\" + spChr + ")").collect(Collectors.joining("|"));
+	public static final Pattern ESCAPE_REGEX_PATTERN = Pattern.compile(ESCAPE_REGEX);
+
+
 	public static <T> List<T> nullToEmpty(List<T> ts) {
 		if (ts == null) {
 			return Collections.emptyList();
@@ -28,10 +33,7 @@ public class Util {
 	}
 
 	public static String escapeRegExp(String s) {
-		String regexp = Stream.of("^", "$", "\\", ".", "*", "+", "*", "?", "(", ")", "[", "]", "{", "}", "|")
-						.map(spChr -> "(\\" + spChr + ")").collect(Collectors.joining("|"));
-
-		return Pattern.compile(regexp).matcher(s).replaceAll("\\\\$0");
+		return ESCAPE_REGEX_PATTERN.matcher(s).replaceAll("\\\\$0");
 	}
 
 	@SafeVarargs

--- a/src/test/java/com/github/vertical_blank/sqlformatter/Benchmark.java
+++ b/src/test/java/com/github/vertical_blank/sqlformatter/Benchmark.java
@@ -1,0 +1,31 @@
+package com.github.vertical_blank.sqlformatter;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class Benchmark {
+
+    public static final String SQL = "SELECT foo, bar, CASE baz WHEN 'one' THEN 1 WHEN 'two' THEN 2 ELSE 3 END FROM table";
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(Benchmark.class.getSimpleName())
+                .forks(1)
+                .build();
+
+        new Runner(opt).run();
+    }
+
+    @org.openjdk.jmh.annotations.Benchmark
+    public void format() {
+        SqlFormatter.format(SQL);
+    }
+}


### PR DESCRIPTION
Currently, many regex patterns are being compiled multiple times during
tokenisation. This change will reuse compiled regex patterns.

Single threaded JMH benchmark for a simple query showed 4X performance
gain with this change. (For complex queries it might be even higher as
some regex were compiled for each token.)

# Perf Readings:

## Before

```
Result "com.github.vertical_blank.sqlformatter.Benchmark.format":
  550102.151 ±(99.9%) 2618.739 ns/op [Average]
  (min, avg, max) = (545433.044, 550102.151, 559765.481), stdev = 3015.744
  CI (99.9%): [547483.411, 552720.890] (assumes normal distribution)


# Run complete. Total time: 00:00:40

Benchmark         Mode  Cnt       Score      Error  Units
Benchmark.format  avgt   20  550102.151 ± 2618.739  ns/op
```

## After

```
Result "com.github.vertical_blank.sqlformatter.Benchmark.format":
  124452.246 ±(99.9%) 406.149 ns/op [Average]
  (min, avg, max) = (123735.574, 124452.246, 125859.623), stdev = 467.722
  CI (99.9%): [124046.097, 124858.395] (assumes normal distribution)


# Run complete. Total time: 00:00:40

Benchmark         Mode  Cnt       Score     Error  Units
Benchmark.format  avgt   20  124452.246 ± 406.149  ns/op
```