### PR TITLE
Add concat operator to standard sql.

### DIFF
--- a/src/main/java/com/github/vertical_blank/sqlformatter/languages/StandardSqlFormatter.java
+++ b/src/main/java/com/github/vertical_blank/sqlformatter/languages/StandardSqlFormatter.java
@@ -379,6 +379,7 @@ public class StandardSqlFormatter extends AbstractFormatter {
         .indexedPlaceholderTypes(Collections.singletonList("?"))
         .namedPlaceholderTypes(Collections.emptyList())
         .lineCommentTypes(Arrays.asList("--"))
+        .operators(Collections.singletonList("||"))
         .build();
   }
 


### PR DESCRIPTION
Concat operator( `||` ) is defined in Standard SQL.
https://fossies.org/linux/dbeaver/docs/sql1992.txt