### PR TITLE
Fix wrong order of indexed placeholders

### DIFF
--- a/src/main/java/com/github/vertical_blank/sqlformatter/core/Params.java
+++ b/src/main/java/com/github/vertical_blank/sqlformatter/core/Params.java
@@ -1,8 +1,8 @@
 package com.github.vertical_blank.sqlformatter.core;
 
+import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Map;
-import java.util.PriorityQueue;
 import java.util.Queue;
 
 /** Handles placeholder replacement with given params. */
@@ -74,7 +74,7 @@ public interface Params {
     private final Queue<?> params;
 
     IndexedParams(List<?> params) {
-      this.params = new PriorityQueue<>(params);
+      this.params = new ArrayDeque<>(params);
     }
 
     public boolean isEmpty() {


### PR DESCRIPTION
Indexed placeholders are not inserted in the provided order.

Code to reproduce the issue:
``` java
 System.out.println(SqlFormatter.format(
    "select * from test where a = ? and b = ? and c = ?",
     Arrays.asList("3", "2", "1")));
```

Generated but wrong output is:
``` sql
select
  *
from
  test
where
  a = 1
  and b = 2
  and c = 3
```

In a correct output, `a` must be assigned `3` and `c` must be assigned `1` instead.


The issue is that `IndexedParams` uses a `PriorityQueue` that stores the placeholder values based on their _natural ordering_ instead of the order of the provided list. This PR proposes to replace `PriorityQueue` with an `ArrayDeque` to fix this issue.