### PR TITLE
Fix spark lambdas

### DIFF
--- a/src/main/java/com/github/vertical_blank/sqlformatter/languages/SparkSqlFormatter.java
+++ b/src/main/java/com/github/vertical_blank/sqlformatter/languages/SparkSqlFormatter.java
@@ -252,7 +252,7 @@ public class SparkSqlFormatter extends AbstractFormatter {
         .indexedPlaceholderTypes(Collections.singletonList("?"))
         .namedPlaceholderTypes(Collections.singletonList("$"))
         .lineCommentTypes(Collections.singletonList("--"))
-        .operators(Arrays.asList("!=", "<=>", "&&", "||", "=="))
+        .operators(Arrays.asList("!=", "<=>", "&&", "||", "==", "->"))
         .build();
   }
 

--- a/src/test/java/com/github/vertical_blank/sqlformatter/SqlFormatterTest.java
+++ b/src/test/java/com/github/vertical_blank/sqlformatter/SqlFormatterTest.java
@@ -75,4 +75,10 @@ public class SqlFormatterTest {
     String format = SqlFormatter.format("SELECT * FROM tbl WHERE foo = ?", Arrays.asList("'bar'"));
     assertEquals(format, "SELECT\n" + "  *\n" + "FROM\n" + "  tbl\n" + "WHERE\n" + "  foo = 'bar'");
   }
+
+  @Test
+  public void withLambdasParams() {
+    String format = SqlFormatter.of(Dialect.SparkSql).format("SELECT aggregate(array(1, 2, 3), 0, (acc, x) -> acc + x, acc -> acc * 10);");
+    assertEquals(format, "SELECT\n" + "  aggregate(array(1, 2, 3), 0, (acc, x) -> acc + x, acc -> acc * 10);");
+  }
 }

--- a/src/test/kotlin/com/github/vertical_blank/sqlformatter/SparkSqlFormatterTest.kt
+++ b/src/test/kotlin/com/github/vertical_blank/sqlformatter/SparkSqlFormatterTest.kt
@@ -31,7 +31,7 @@ object SparkSqlFormatterTest :
         supportsSchema(formatter)
         supportsOperators(
           formatter,
-          listOf("!=", "%", "|", "&", "^", "~", "!", "<=>", "%", "&&", "||", "==")
+          listOf("!=", "%", "|", "&", "^", "~", "!", "<=>", "%", "&&", "||", "==", "->")
         )
         supportsJoin(
           formatter,


### PR DESCRIPTION
This PR solves the following issue:

In Spark SQL, it is possible to use lambda.

However, the formatter is breaking valid SQL statements:

```java
import static org.assertj.core.api.Assertions.assertThat;

import com.github.vertical_blank.sqlformatter.SqlFormatter;
import com.github.vertical_blank.sqlformatter.languages.Dialect;
import org.junit.jupiter.api.Test;

public class TestFormatter {

	String SQL_INPUT = "SELECT aggregate(array(1, 2, 3), 0, (acc, x) -> acc + x, acc -> acc * 10);";

	@Test
	public void testFormatter() {
		assertThat(SqlFormatter.of(Dialect.SparkSql).format(SQL_INPUT)).contains("->");

	}

}
```

The output is:

```
java.lang.AssertionError: 
Expecting actual:
  "SELECT
  aggregate(array(1, 2, 3), 0, (acc, x) - > acc + x, acc - > acc * 10);"
to contain:
  "->"
```

In order to be valid Spark SQL, the symbol `->` should be kept as a whole and not split into `- >`