### PR TITLE
Handle Go keyword for TSQL

### DIFF
--- a/src/main/java/com/github/vertical_blank/sqlformatter/languages/TSqlFormatter.java
+++ b/src/main/java/com/github/vertical_blank/sqlformatter/languages/TSqlFormatter.java
@@ -199,6 +199,7 @@ public class TSqlFormatter extends AbstractFormatter {
 
   private static final List<String> reservedTopLevelWords =
       Arrays.asList(
+          "GO",
           "ADD",
           "ALTER COLUMN",
           "ALTER TABLE",
@@ -226,6 +227,7 @@ public class TSqlFormatter extends AbstractFormatter {
 
   private static final List<String> reservedNewlineWords =
       Arrays.asList(
+          "GO",
           "AND",
           "ELSE",
           "OR",


### PR DESCRIPTION
Handle `Go` keyword as `reservedNewlineWords`.

Origin SQL. 

```sql
alter table t1 add n_col int null 
go 
update t1 set c_con=0
```

before

```sql
ALTER TABLE
    t1
ADD
    n_col int NULL go
UPDATE
    t1
SET
    c_con = 0
```


after:
```sql
ALTER TABLE
    t1
ADD
    n_col int NULL
GO
UPDATE
    t1
SET
    c_con = 0
```