### PR TITLE
new format config for skipping white spaces before and after block pa…

### DIFF
--- a/src/main/java/com/github/vertical_blank/sqlformatter/core/AbstractFormatter.java
+++ b/src/main/java/com/github/vertical_blank/sqlformatter/core/AbstractFormatter.java
@@ -167,7 +167,9 @@ public abstract class AbstractFormatter implements DialectConfigurator {
 
     if (!this.inlineBlock.isActive()) {
       this.indentation.increaseBlockLevel();
-      query = this.addNewline(query);
+      if (!cfg.skipWhitespaceNearBlockParentheses) {
+        query = this.addNewline(query);
+      }
     }
     return query;
   }
@@ -179,7 +181,11 @@ public abstract class AbstractFormatter implements DialectConfigurator {
       return this.formatWithSpaceAfter(token, query);
     } else {
       this.indentation.decreaseBlockLevel();
-      return this.formatWithSpaces(token, this.addNewline(query));
+      if (!cfg.skipWhitespaceNearBlockParentheses) {
+        return this.formatWithSpaces(token, this.addNewline(query));
+      } else {
+        return this.formatWithoutSpaces(token, query);
+      }
     }
   }
 

--- a/src/main/java/com/github/vertical_blank/sqlformatter/core/FormatConfig.java
+++ b/src/main/java/com/github/vertical_blank/sqlformatter/core/FormatConfig.java
@@ -14,18 +14,21 @@ public class FormatConfig {
   public final Params params;
   public final boolean uppercase;
   public final Integer linesBetweenQueries;
+  public final boolean skipWhitespaceNearBlockParentheses;
 
   FormatConfig(
       String indent,
       int maxColumnLength,
       Params params,
       boolean uppercase,
-      Integer linesBetweenQueries) {
+      Integer linesBetweenQueries,
+      boolean skipWhitespaceNearBlockParentheses) {
     this.indent = indent;
     this.maxColumnLength = maxColumnLength;
     this.params = params == null ? Params.EMPTY : params;
     this.uppercase = uppercase;
     this.linesBetweenQueries = linesBetweenQueries;
+    this.skipWhitespaceNearBlockParentheses = skipWhitespaceNearBlockParentheses;
   }
 
   /**
@@ -44,6 +47,7 @@ public class FormatConfig {
     private Params params;
     private boolean uppercase;
     private Integer linesBetweenQueries;
+    private boolean skipWhitespaceNearBlockParentheses;
 
     FormatConfigBuilder() {}
 
@@ -109,13 +113,29 @@ public class FormatConfig {
     }
 
     /**
+     * @param skipWhitespaceNearBlockParentheses skip adding whitespace before and after block
+     *     Parentheses
+     * @return This
+     */
+    public FormatConfigBuilder skipWhitespaceNearBlockParentheses(
+        boolean skipWhitespaceNearBlockParentheses) {
+      this.skipWhitespaceNearBlockParentheses = skipWhitespaceNearBlockParentheses;
+      return this;
+    }
+
+    /**
      * Returns an instance of FormatConfig created from the fields set on this builder.
      *
      * @return FormatConfig
      */
     public FormatConfig build() {
       return new FormatConfig(
-          this.indent, this.maxColumnLength, this.params, this.uppercase, this.linesBetweenQueries);
+          this.indent,
+          this.maxColumnLength,
+          this.params,
+          this.uppercase,
+          this.linesBetweenQueries,
+          this.skipWhitespaceNearBlockParentheses);
     }
   }
 }


### PR DESCRIPTION
With this new config parameter you are able to skip white spaces before and after block parentheses.
For example
Without this parameter:
CREATE VIEW sakila.v_exampl (customer, phone, title) AS select concat(sakila.customer.last_name,', ',sakila.customer.first_name) AS customer,sakila.address.phone AS phone,sakila.film.title AS title from ((((sakila.rental join sakila.customer on((sakila.rental.customer_id = sakila.customer.customer_id))) join sakila.address on((sakila.customer.address_id = sakila.address.address_id))) join sakila.inventory on((sakila.rental.inventory_id = sakila.inventory.inventory_id))) join sakila.film on((sakila.inventory.film_id = sakila.film.film_id))) where ((sakila.rental.return_date is null) and ((sakila.rental.rental_date + interval sakila.film.rental_duration day) < curdate())) order by sakila.film.title limit 5
Result:
CREATE VIEW sakila.v_exampl (customer, phone, title) AS
select
  concat(
    sakila.customer.last_name,
    ', ',
    sakila.customer.first_name
  ) AS customer,
  sakila.address.phone AS phone,
  sakila.film.title AS title
from
  (
    (
      (
        (
          sakila.rental
          join sakila.customer on(
            (
              sakila.rental.customer_id = sakila.customer.customer_id
            )
          )
        )
        join sakila.address on(
          (
            sakila.customer.address_id = sakila.address.address_id
          )
        )
      )
      join sakila.inventory on(
        (
          sakila.rental.inventory_id = sakila.inventory.inventory_id
        )
      )
    )
    join sakila.film on((sakila.inventory.film_id = sakila.film.film_id))
  )
where
  (
    (sakila.rental.return_date is null)
    and (
      (
        sakila.rental.rental_date + interval sakila.film.rental_duration day
      ) < curdate()
    )
  )
order by
  sakila.film.title
limit
  5

With this new parameter
CREATE VIEW sakila.v_exampl (customer, phone, title) AS
select
  concat(sakila.customer.last_name,
    ', ',
    sakila.customer.first_name)AS customer,
  sakila.address.phone AS phone,
  sakila.film.title AS title
from
  ((((sakila.rental
          join sakila.customer on((sakila.rental.customer_id = sakila.customer.customer_id)))
        join sakila.address on((sakila.customer.address_id = sakila.address.address_id)))
      join sakila.inventory on((sakila.rental.inventory_id = sakila.inventory.inventory_id)))
    join sakila.film on((sakila.inventory.film_id = sakila.film.film_id)))
where
  ((sakila.rental.return_date is null)
    and ((sakila.rental.rental_date + interval sakila.film.rental_duration day)< curdate()))
order by
  sakila.film.title
limit
  5
